### PR TITLE
Test: verify learning system records outcomes

### DIFF
--- a/data/reviews/review-54.json
+++ b/data/reviews/review-54.json
@@ -1,0 +1,60 @@
+{
+  "overallRecommendation": "APPROVE",
+  "agents": [
+    {
+      "agentName": "Code Quality",
+      "riskLevel": "LOW",
+      "recommendation": "APPROVE",
+      "findings": [
+        "Not enough context in diff to assess whether the new Javadoc description in `java/temporal-review/src/main/java/com/utm/temporal/learning/HeuristicsEngine.java` matches the implementation. Hunk `@@ -11,6 +11,10 @@` adds: `\"The engine loads learned rules from the database and applies them to each agent's output...\"` but no code changes are shown."
+      ]
+    },
+    {
+      "agentName": "Test Quality",
+      "riskLevel": "LOW",
+      "recommendation": "APPROVE",
+      "findings": [
+        "This diff is documentation/comment-only in HeuristicsEngine and does not introduce executable logic, branching, validation, or API behavior changes. No new tests are required for the code change itself.",
+        "Test Suggestion 1: Add a unit test that verifies the engine still produces identical output for a representative input before and after loading learned heuristics, to guard against future regressions in the documented behavior.",
+        "Test Suggestion 2: Add a test for the boundary case where the learned-heuristics list is empty or null-equivalent from the data source, ensuring the engine falls back to deterministic post-processing without errors.",
+        "Test Suggestion 3: Add an integration-style test covering a learned heuristic that filters a false positive and one that calibrates severity, verifying the data flow from stored rule to final AgentResult output."
+      ]
+    },
+    {
+      "agentName": "Security",
+      "riskLevel": "LOW",
+      "recommendation": "APPROVE",
+      "findings": [
+        "No security issues detected. The diff only updates documentation comments in `HeuristicsEngine.java` and does not introduce changes to authentication, authorization, input handling, or secret handling."
+      ]
+    },
+    {
+      "agentName": "Complexity",
+      "riskLevel": "LOW",
+      "recommendation": "APPROVE",
+      "findings": [
+        "Cyclomatic Complexity: 0",
+        "Cognitive Complexity: 0",
+        "Primary driver: documentation-only change; no executable control flow was added or modified"
+      ]
+    },
+    {
+      "agentName": "Priority",
+      "riskLevel": "LOW",
+      "recommendation": "APPROVE",
+      "findings": [
+        "P3: Documentation-only change in `HeuristicsEngine` should be kept in sync with implementation if the Javadoc is intended to describe runtime behavior [CodeQuality] - Consider adding or updating a test that exercises the documented learning-rule flow to prevent drift.",
+        "P3: No executable behavior changed, so no immediate test additions are required; however, a small regression test for empty/null learned-heuristics input would help protect the fallback path [TestQuality] - Add a focused unit test if this code path exists in the implementation.",
+        "P3: No complexity concerns were introduced; the change is comment-only [Complexity] - No action needed."
+      ]
+    }
+  ],
+  "metadata": {
+    "generatedAt": "2026-04-13T15:52:34.236Z",
+    "tookMs": 10829,
+    "model": "gpt-5.4-mini"
+  },
+  "prNumber": 54,
+  "prTitle": "Test: verify learning system records outcomes",
+  "author": "nadvolod"
+}

--- a/java/temporal-review/src/main/java/com/utm/temporal/learning/HeuristicsEngine.java
+++ b/java/temporal-review/src/main/java/com/utm/temporal/learning/HeuristicsEngine.java
@@ -11,6 +11,10 @@ import java.util.stream.Collectors;
 /**
  * Applies approved heuristics and severity calibrations to AgentResults.
  * This is deterministic post-processing — no LLM calls.
+ *
+ * The engine loads learned rules from the database and applies them to each
+ * agent's output, filtering false positives and calibrating severity levels
+ * based on historical review outcome data.
  */
 public class HeuristicsEngine {
     private final List<LearnedHeuristic> heuristics;


### PR DESCRIPTION
## Summary
- Small javadoc addition to HeuristicsEngine to test the learning pipeline

## Purpose
This PR exists to verify that the AI review system:
1. Runs the review with `repository` field set
2. Records the outcome to Neon Postgres
3. The learning worker can collect the outcome

Generated with [Claude Code](https://claude.com/claude-code)