### PR TITLE
Add Impact Analysis Agent for QA teams

### DIFF
--- a/data/reviews/review-72.json
+++ b/data/reviews/review-72.json
@@ -1,0 +1,95 @@
+{
+  "overallRecommendation": "REQUEST_CHANGES",
+  "agents": [
+    {
+      "agentName": "Code Quality",
+      "riskLevel": "MEDIUM",
+      "recommendation": "REQUEST_CHANGES",
+      "findings": [
+        "Potential mixed abstraction / leaky boundary in `java/temporal-review/src/main/java/com/utm/temporal/agent/ImpactAnalysisAgent.java` @@ -27,6 +27,48 @@: `\"Impact Analysis Agent - identifies the blast radius of code changes for QA teams.\"` and `\"public AgentResult analyze(String prTitle, String prDescription, String diff, String learningContext)\"` combine prompt construction, LLM invocation, JSON parsing, and token bookkeeping in one method. Smallest refactoring: Extract Function / Separate Query from Modifier by moving prompt building and response parsing into dedicated helpers.",
+        "Potential exception misuse / unsafe fallback in `java/temporal-review/src/main/java/com/utm/temporal/agent/ImpactAnalysisAgent.java` @@ -27,6 +27,48 @@: `catch (Exception e) { throw new RuntimeException(\"Impact Analysis Agent failed: \" + e.getMessage(), e); }` swallows the original boundary-specific failure type and collapses all errors into a generic runtime exception. Smallest refactoring: Catch specific exceptions and rethrow a domain-specific exception or let checked boundary failures propagate with context.",
+        "Potential hidden coupling / temporal coupling in `java/temporal-review/src/main/java/com/utm/temporal/workflow/PRReviewWorkflowImpl.java` @@ -85,35 +88,42 @@: `// 5. Call Impact Analysis Agent` followed by `// 6. Call Priority Agent with results from other agents` and `priorityActivity.prioritizeIssues(request, results);` means the new agent is now part of the ordering contract for downstream prioritization. Not enough context in diff to assess whether `PriorityAgent` expects this new result shape; if it does, the dependency should be made explicit. Smallest refactoring: Introduce Parameter Object or make the aggregation contract explicit in the priority API.",
+        "Potential naming inconsistency / noise in `java/temporal-review/src/main/java/com/utm/temporal/activity/ImpactAnalysisActivityImpl.java` @@ -1,0 +1,19 @@: `analyze(ReviewRequest pullRequest)` passes `pullRequest.prTitle`, `pullRequest.prDescription`, `pullRequest.diff` directly. The parameter name `pullRequest` is fine, but the method name `analyze` is generic while the activity is specifically impact analysis. Not enough context in diff to assess whether this matches the naming convention used by other activities. Smallest refactoring: keep verb-based naming but consider a more specific method name if the interface is public and ambiguous."
+      ],
+      "promptTokens": 0,
+      "completionTokens": 0
+    },
+    {
+      "agentName": "Test Quality",
+      "riskLevel": "MEDIUM",
+      "recommendation": "REQUEST_CHANGES",
+      "findings": [
+        "The diff introduces new runtime logic for a fifth agent (Impact Analysis), wires it into the workflow, and adds a new prompt/resource, but coverage is only a minimal prompt-loader assertion; there are no tests for the new agent implementation or workflow integration.",
+        "Test Suggestion 1: Add a unit test for ImpactAnalysisAgent.analyze() that mocks LlmClient and verifies it builds the expected system/user messages, uses the configured model/options, and correctly maps a valid JSON response into AgentResult, including token counts.",
+        "Test Suggestion 2: Add failure-path tests for ImpactAnalysisAgent.analyze() covering malformed JSON from the LLM and LlmClient exceptions, asserting the method throws the wrapped RuntimeException with the expected message so error handling is stable.",
+        "Test Suggestion 3: Add a workflow/activity integration test for PRReviewWorkflowImpl or WorkerApp registration to confirm ImpactAnalysisActivity is invoked in the correct sequence, its result is included in the results passed to PriorityActivity, and the workflow still behaves correctly when the new agent returns a high-risk finding."
+      ],
+      "promptTokens": 0,
+      "completionTokens": 0
+    },
+    {
+      "agentName": "Security",
+      "riskLevel": "LOW",
+      "recommendation": "APPROVE",
+      "findings": [
+        "No security issues detected. The diff adds a new Impact Analysis agent, prompt resources, and workflow wiring without introducing secrets handling, authorization changes, or unsafe input sinks."
+      ],
+      "promptTokens": 0,
+      "completionTokens": 0
+    },
+    {
+      "agentName": "Complexity",
+      "riskLevel": "LOW",
+      "recommendation": "APPROVE",
+      "findings": [
+        "Cyclomatic Complexity: 4",
+        "Cognitive Complexity: 4",
+        "Primary driver: straightforward agent wiring and a single try/catch path in the new ImpactAnalysisAgent"
+      ],
+      "promptTokens": 0,
+      "completionTokens": 0
+    },
+    {
+      "agentName": "Impact Analysis",
+      "riskLevel": "MEDIUM",
+      "recommendation": "REQUEST_CHANGES",
+      "findings": [
+        "[Direct] Added new ImpactAnalysisAgent, ImpactAnalysisActivity, and ImpactAnalysisActivityImpl, and wired them into WorkerApp and PRReviewWorkflowImpl so the workflow now executes 6 agents instead of 5.",
+        "[Direct] Added new prompt resource at src/main/resources/prompts/impact-analysis.md and updated priority prompt text to recognize ImpactAnalysis as a source agent.",
+        "[Indirect] PRReviewWorkflowImpl now passes the new agent result into PriorityAgent; any priority consolidation logic that assumes only 5 agent results may need validation, but the diff does not show PriorityAgent implementation.",
+        "[Indirect] WorkerApp registration changed, so Temporal worker startup and activity binding for the new AnalyzeImpact activity should be verified end-to-end; no startup or registration tests are shown in the diff.",
+        "[Test Gap] Only PromptLoaderTest was updated; there are no visible tests covering ImpactAnalysisAgent JSON parsing, LLM invocation options, or ImpactAnalysisActivityImpl wiring.",
+        "[Test Gap] No visible workflow test asserts the new 6-step execution order, inclusion of Impact Analysis in aggregated results, or that heuristics are applied to the new agent output.",
+        "[QA Focus] Regression-test PR review runs to confirm the new Impact Analysis step appears in output, does not break existing Code/Test/Security/Complexity/Priority results, and that the final priority summary still consolidates all agent findings correctly.",
+        "[QA Focus] Verify prompt loading for 'impact-analysis' and that the agent returns valid AgentResult JSON with findings prefixed as [Direct], [Indirect], [Test Gap], and [QA Focus]."
+      ],
+      "promptTokens": 0,
+      "completionTokens": 0
+    },
+    {
+      "agentName": "Priority",
+      "riskLevel": "MEDIUM",
+      "recommendation": "REQUEST_CHANGES",
+      "findings": [
+        "P1: New ImpactAnalysisAgent and workflow wiring lack unit and integration coverage; add tests for prompt construction, LLM JSON parsing, token accounting, failure paths, and 6-step workflow/worker registration to prevent regressions [TestQuality] - Add focused tests before merge",
+        "P2: ImpactAnalysisAgent currently mixes prompt building, LLM invocation, JSON parsing, and token bookkeeping in one method; extract helpers to improve readability and maintainability [CodeQuality] - Refactor into smaller methods",
+        "P2: Error handling in ImpactAnalysisAgent collapses all failures into a generic RuntimeException; catch specific exceptions or use a domain-specific exception so callers can distinguish parse, transport, and model failures [CodeQuality] - Preserve failure context with typed exceptions",
+        "P2: PRReviewWorkflowImpl now depends on the new agent result being passed into PriorityActivity; make the aggregation contract explicit and verify PriorityAgent handles the expanded result set [CodeQuality][ImpactAnalysis] - Update the priority API or add contract tests",
+        "P3: ImpactAnalysisActivityImpl method naming is generic relative to the new activity purpose; consider a more specific name if it improves API clarity [CodeQuality] - Align naming with existing activity conventions"
+      ],
+      "promptTokens": 1742,
+      "completionTokens": 271
+    }
+  ],
+  "metadata": {
+    "generatedAt": "2026-04-16T15:04:23.992Z",
+    "tookMs": 20038,
+    "model": "gpt-5.4-mini",
+    "totalPromptTokens": 1742,
+    "totalCompletionTokens": 271,
+    "estimatedCost": 0.002526
+  },
+  "prNumber": 72,
+  "prTitle": "Add Impact Analysis Agent for QA teams",
+  "author": "nadvolod"
+}

--- a/java/temporal-review/src/main/java/com/utm/temporal/WorkerApp.java
+++ b/java/temporal-review/src/main/java/com/utm/temporal/WorkerApp.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.utm.temporal.activity.*;
 import com.utm.temporal.agent.ComplexityAgent;
 import com.utm.temporal.agent.CodeQualityAgent;
+import com.utm.temporal.agent.ImpactAnalysisAgent;
 import com.utm.temporal.agent.PriorityAgent;
 import com.utm.temporal.agent.SecurityAgent;
 import com.utm.temporal.agent.TestQualityAgent;
@@ -101,6 +102,7 @@ public class WorkerApp {
             SecurityAgent securityAgent = new SecurityAgent();
             PriorityAgent priorityAgent = new PriorityAgent();
             ComplexityAgent complexityAgent = new ComplexityAgent();
+            ImpactAnalysisAgent impactAnalysisAgent = new ImpactAnalysisAgent();
 
             // Register activity implementations
             worker.registerActivitiesImplementations(
@@ -109,6 +111,7 @@ public class WorkerApp {
                     new SecurityQualityActivityImpl(securityAgent),
                     new PriorityActivityImpl(priorityAgent),
                     new ComplexityQualityActivityImpl(complexityAgent),
+                    new ImpactAnalysisActivityImpl(impactAnalysisAgent),
                     new OutcomeRecordingActivityImpl(dbClient),
                     new LoadInsightsActivityImpl(dbClient));
 

--- a/java/temporal-review/src/main/java/com/utm/temporal/activity/ImpactAnalysisActivity.java
+++ b/java/temporal-review/src/main/java/com/utm/temporal/activity/ImpactAnalysisActivity.java
@@ -1,0 +1,12 @@
+package com.utm.temporal.activity;
+
+import com.utm.temporal.model.AgentResult;
+import com.utm.temporal.model.ReviewRequest;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+
+@ActivityInterface
+public interface ImpactAnalysisActivity {
+    @ActivityMethod(name = "AnalyzeImpact")
+    AgentResult analyze(ReviewRequest pullRequest);
+}

--- a/java/temporal-review/src/main/java/com/utm/temporal/activity/ImpactAnalysisActivityImpl.java
+++ b/java/temporal-review/src/main/java/com/utm/temporal/activity/ImpactAnalysisActivityImpl.java
@@ -1,0 +1,19 @@
+package com.utm.temporal.activity;
+
+import com.utm.temporal.agent.ImpactAnalysisAgent;
+import com.utm.temporal.model.AgentResult;
+import com.utm.temporal.model.ReviewRequest;
+
+public class ImpactAnalysisActivityImpl implements ImpactAnalysisActivity {
+    private final ImpactAnalysisAgent impactAnalysisAgent;
+
+    public ImpactAnalysisActivityImpl(ImpactAnalysisAgent impactAnalysisAgent) {
+        this.impactAnalysisAgent = impactAnalysisAgent;
+    }
+
+    @Override
+    public AgentResult analyze(ReviewRequest pullRequest) {
+        return impactAnalysisAgent.analyze(pullRequest.prTitle,
+                pullRequest.prDescription, pullRequest.diff);
+    }
+}

--- a/java/temporal-review/src/main/java/com/utm/temporal/agent/ImpactAnalysisAgent.java
+++ b/java/temporal-review/src/main/java/com/utm/temporal/agent/ImpactAnalysisAgent.java
@@ -1,0 +1,74 @@
+package com.utm.temporal.agent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.utm.temporal.llm.LlmClient;
+import com.utm.temporal.llm.LlmOptions;
+import com.utm.temporal.llm.Message;
+import com.utm.temporal.llm.OpenAiLlmClient;
+import com.utm.temporal.model.AgentResult;
+import com.utm.temporal.util.PromptLoader;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Impact Analysis Agent - identifies the blast radius of code changes for QA teams.
+ * Analyzes which other code areas are affected by the current change.
+ */
+public class ImpactAnalysisAgent {
+
+    private final LlmClient llmClient;
+    private final ObjectMapper objectMapper;
+
+    public ImpactAnalysisAgent(LlmClient llmClient) {
+        this.llmClient = llmClient;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public ImpactAnalysisAgent() {
+        this.llmClient = new OpenAiLlmClient();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public AgentResult analyze(String prTitle, String prDescription, String diff, String learningContext) {
+        try {
+            String systemPrompt = buildSystemPrompt() + (learningContext != null ? learningContext : "");
+
+            String userPrompt = String.format(
+                "PR Title: %s\n\nPR Description: %s\n\nDiff:\n%s",
+                prTitle,
+                prDescription,
+                diff
+            );
+
+            List<Message> messages = Arrays.asList(
+                new Message("system", systemPrompt),
+                new Message("user", userPrompt)
+            );
+
+            LlmOptions options = new LlmOptions(
+                System.getenv().getOrDefault("OPENAI_MODEL", OpenAiLlmClient.DEFAULT_MODEL),
+                0.2,
+                "json_object"
+            );
+
+            String response = llmClient.chat(messages, options);
+
+            AgentResult result = objectMapper.readValue(response, AgentResult.class);
+            result.promptTokens = llmClient.getLastPromptTokens();
+            result.completionTokens = llmClient.getLastCompletionTokens();
+            return result;
+
+        } catch (Exception e) {
+            throw new RuntimeException("Impact Analysis Agent failed: " + e.getMessage(), e);
+        }
+    }
+
+    public AgentResult analyze(String prTitle, String prDescription, String diff) {
+        return analyze(prTitle, prDescription, diff, null);
+    }
+
+    private String buildSystemPrompt() {
+        return PromptLoader.loadPrompt("impact-analysis");
+    }
+}

--- a/java/temporal-review/src/main/java/com/utm/temporal/model/AgentResult.java
+++ b/java/temporal-review/src/main/java/com/utm/temporal/model/AgentResult.java
@@ -6,7 +6,7 @@ import java.util.List;
  * Result from a single AI agent review.
  */
 public class AgentResult {
-    public String agentName;        // "Code Quality", "Test Quality", "Complexity", "Security"
+    public String agentName;        // "Code Quality", "Test Quality", "Complexity", "Security", "Impact Analysis"
     public String riskLevel;        // "LOW", "MEDIUM", "HIGH"
     public String recommendation;   // "APPROVE", "REQUEST_CHANGES", "BLOCK"
     public List<String> findings;

--- a/java/temporal-review/src/main/java/com/utm/temporal/workflow/PRReviewWorkflowImpl.java
+++ b/java/temporal-review/src/main/java/com/utm/temporal/workflow/PRReviewWorkflowImpl.java
@@ -43,6 +43,9 @@ public class PRReviewWorkflowImpl implements PRReviewWorkflow {
     private final SecurityQualityActivity securityQualityActivity = Workflow.newActivityStub(
             SecurityQualityActivity.class, ACTIVITY_OPTIONS
     );
+    private final ImpactAnalysisActivity impactAnalysisActivity = Workflow.newActivityStub(
+            ImpactAnalysisActivity.class, ACTIVITY_OPTIONS
+    );
     private final PriorityActivity priorityActivity = Workflow.newActivityStub(
             PriorityActivity.class, ACTIVITY_OPTIONS
     );
@@ -85,35 +88,42 @@ public class PRReviewWorkflowImpl implements PRReviewWorkflow {
             List<AgentResult> results = new ArrayList<>();
 
             // 1. Call Code Quality Agent
-            logger.info("[1/5] Calling Code Quality Agent...");
+            logger.info("[1/6] Calling Code Quality Agent...");
             AgentResult codeQuality = codeQualityActivity.analyze(request);
             codeQuality = heuristicsEngine.apply(codeQuality, request.diff);
             results.add(codeQuality);
             logger.info("      → " + codeQuality.recommendation + " (Risk: " + codeQuality.riskLevel + ")");
 
             // 2. Call Test Quality Agent
-            logger.info("[2/5] Calling Test Quality Agent...");
+            logger.info("[2/6] Calling Test Quality Agent...");
             AgentResult testQuality = testQualityActivity.analyze(request);
             testQuality = heuristicsEngine.apply(testQuality, request.diff);
             results.add(testQuality);
             logger.info("      → " + testQuality.recommendation + " (Risk: " + testQuality.riskLevel + ")");
 
             // 3. Call Security Agent
-            logger.info("[3/5] Calling Security Agent...");
+            logger.info("[3/6] Calling Security Agent...");
             AgentResult security = securityQualityActivity.analyze(request);
             security = heuristicsEngine.apply(security, request.diff);
             results.add(security);
             logger.info("      → " + security.recommendation + " (Risk: " + security.riskLevel + ")");
 
             // 4. Call Complexity Agent
-            logger.info("[4/5] Calling Complexity Agent...");
+            logger.info("[4/6] Calling Complexity Agent...");
             AgentResult complexity = complexityQualityActivity.analyze(request);
             complexity = heuristicsEngine.apply(complexity, request.diff);
             results.add(complexity);
             logger.info("      → " + complexity.recommendation + " (Risk: " + complexity.riskLevel + ")");
 
-            // 5. Call Priority Agent with results from other agents
-            logger.info("[5/5] Calling Priority Agent...");
+            // 5. Call Impact Analysis Agent
+            logger.info("[5/6] Calling Impact Analysis Agent...");
+            AgentResult impactAnalysis = impactAnalysisActivity.analyze(request);
+            impactAnalysis = heuristicsEngine.apply(impactAnalysis, request.diff);
+            results.add(impactAnalysis);
+            logger.info("      → " + impactAnalysis.recommendation + " (Risk: " + impactAnalysis.riskLevel + ")");
+
+            // 6. Call Priority Agent with results from other agents
+            logger.info("[6/6] Calling Priority Agent...");
             AgentResult priority = priorityActivity.prioritizeIssues(request, results);
             results.add(priority);
             logger.info("      → " + priority.recommendation + " (Risk: " + priority.riskLevel + ")");

--- a/java/temporal-review/src/main/resources/prompts/impact-analysis.md
+++ b/java/temporal-review/src/main/resources/prompts/impact-analysis.md
@@ -1,0 +1,48 @@
+# Impact Analysis Agent
+
+You are an Impact Analysis Agent analyzing pull request diffs to identify the blast radius of code changes. Your audience is QA Managers and Testers who need to know what to regression test.
+
+## Your Tasks
+
+1. **Direct Impacts**: Identify files/modules explicitly changed in the diff
+2. **Indirect Impacts**: Identify files/modules likely affected but NOT in the diff (callers, dependents, shared state, consumers of changed APIs/interfaces)
+3. **Test Coverage Gaps**: Areas that should be tested based on the change footprint but are not visibly tested in the diff
+4. **Risk Areas for QA**: Specific functionality, user flows, or integration points testers should focus on
+
+## Hard Constraints
+
+- Base findings ONLY on what is visible in the diff.
+- Do NOT invent files or behavior not shown.
+- Every finding MUST be prefixed with its category: `[Direct]`, `[Indirect]`, `[Test Gap]`, or `[QA Focus]`.
+- NO generic fluff. Be specific and actionable for testers.
+- If the diff lacks context to assess something, say so.
+
+## Risk Level Guidelines
+
+- **LOW**: Changes are isolated, minimal blast radius, clear boundaries
+- **MEDIUM**: Changes affect shared code, APIs, or interfaces with known dependents
+- **HIGH**: Changes affect critical shared infrastructure, widely-used base classes, or cross-cutting concerns with unclear boundaries
+
+## Recommendation Guidelines
+
+- **BLOCK**: Changes touch critical shared infrastructure with no visible regression testing plan
+- **REQUEST_CHANGES**: Significant indirect impacts identified that need test coverage before merge
+- **APPROVE**: Changes are well-isolated or indirect impacts are minimal/already tested
+
+## Response Format
+
+Respond ONLY with valid JSON matching this exact structure:
+
+```json
+{
+  "agentName": "Impact Analysis",
+  "riskLevel": "LOW|MEDIUM|HIGH",
+  "recommendation": "APPROVE|REQUEST_CHANGES|BLOCK",
+  "findings": [
+    "[Direct] specific finding about changed files",
+    "[Indirect] specific finding about affected dependents",
+    "[Test Gap] specific finding about missing test coverage",
+    "[QA Focus] specific area testers should focus on"
+  ]
+}
+```

--- a/java/temporal-review/src/main/resources/prompts/priority.md
+++ b/java/temporal-review/src/main/resources/prompts/priority.md
@@ -4,7 +4,7 @@ You are a Priority Agent that consolidates and ranks findings from multiple code
 
 ## Your Tasks
 
-1. **Consolidate** findings from Code Quality, Test Quality, Security, and Complexity agents
+1. **Consolidate** findings from Code Quality, Test Quality, Security, Complexity, and Impact Analysis agents
 2. **Rank by severity**: P0-Critical (blockers), P1-High, P2-Medium, P3-Low
 3. **Deduplicate** overlapping concerns across agents
 4. **Order by actionability**: quick wins first, then larger refactors
@@ -32,7 +32,7 @@ You are a Priority Agent that consolidates and ranks findings from multiple code
 ## IMPORTANT
 
 - Each finding should start with priority level: "P0:", "P1:", "P2:", or "P3:"
-- Include the source agent in brackets: [Security], [CodeQuality], [TestQuality], [Complexity]
+- Include the source agent in brackets: [Security], [CodeQuality], [TestQuality], [Complexity], [ImpactAnalysis]
 - Add brief actionable guidance after each finding
 - If multiple agents report similar issues, consolidate into one finding
 

--- a/java/temporal-review/src/test/java/com/utm/temporal/util/PromptLoaderTest.java
+++ b/java/temporal-review/src/test/java/com/utm/temporal/util/PromptLoaderTest.java
@@ -43,6 +43,13 @@ class PromptLoaderTest {
     }
 
     @Test
+    void loadPrompt_impactAnalysis_returnsContent() {
+        String prompt = PromptLoader.loadPrompt("impact-analysis");
+        assertNotNull(prompt);
+        assertTrue(prompt.contains("Impact Analysis"));
+    }
+
+    @Test
     void loadPrompt_missingFile_throwsRuntimeException() {
         RuntimeException ex = assertThrows(RuntimeException.class, () ->
             PromptLoader.loadPrompt("nonexistent-agent")
@@ -53,7 +60,7 @@ class PromptLoaderTest {
 
     @Test
     void loadPrompt_allPromptsContainJsonResponseFormat() {
-        String[] agents = {"code-quality", "security", "test-quality", "complexity", "priority"};
+        String[] agents = {"code-quality", "security", "test-quality", "complexity", "priority", "impact-analysis"};
         for (String agent : agents) {
             String prompt = PromptLoader.loadPrompt(agent);
             assertTrue(prompt.contains("agentName"), agent + " prompt missing agentName in JSON format");

--- a/sample-output.json
+++ b/sample-output.json
@@ -21,6 +21,11 @@
     "recommendation" : "APPROVE",
     "findings" : [ "Cyclomatic Complexity: 6", "Cognitive Complexity: 8", "Primary driver: simple conditional checks" ]
   }, {
+    "agentName" : "Impact Analysis",
+    "riskLevel" : "MEDIUM",
+    "recommendation" : "REQUEST_CHANGES",
+    "findings" : [ "[Direct] AuthService.java modified — login() and verifyToken() methods changed", "[Indirect] Any controller or middleware calling AuthService.login() or AuthService.verifyToken() may be affected — verify all authentication entry points", "[Test Gap] No integration tests visible for token verification flow with downstream services that depend on JWT claims", "[QA Focus] End-to-end login flow should be regression-tested, including token expiry and invalid token scenarios across all client types" ]
+  }, {
     "agentName" : "Priority",
     "riskLevel" : "MEDIUM",
     "recommendation" : "REQUEST_CHANGES",


### PR DESCRIPTION
## Summary
- Adds a new **Impact Analysis Agent** that identifies the blast radius of code changes for QA Managers and Testers
- Findings are categorized as `[Direct]`, `[Indirect]`, `[Test Gap]`, and `[QA Focus]`
- Runs as step 5/6 in the workflow, before Priority aggregation

Closes #70

## Changes
- 4 new files: agent, activity interface/impl, prompt
- Wired into workflow (6 steps now), worker registration, and Priority prompt
- Updated PromptLoaderTest with new agent coverage
- All 48 tests pass

## Test plan
- [x] `mvn clean test` — 48 tests pass, BUILD SUCCESS
- [ ] Run with `DUMMY_MODE=true` to verify workflow includes all 6 agents
- [ ] Run against a real PR to validate LLM output format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Impact Analysis Agent to the review workflow; it assesses PR diffs for regression blast radius, test gaps, indirect impacts, and QA risk, and is included as an additional analysis step (workflow now 6-step).
* **Documentation**
  * Added Impact Analysis prompt/specification and updated consolidation guidance to include its findings.
* **Tests**
  * Added tests to validate the new prompt and include it in JSON-format checks.
* **Chores**
  * Added sample output and a review artifact demonstrating Impact Analysis results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->